### PR TITLE
docs: Add comprehensive end-to-end repository documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,56 +1,84 @@
-## Master AI Agentic Engineering -  build autonomous AI Agents
+# Master AI Agentic Engineering - Autonomous AI Agent Development Course
 
-### 6 week journey to code and deploy AI Agents with OpenAI Agents SDK, CrewAI, LangGraph, AutoGen and MCP
+Welcome to the repository for the "Master AI Agentic Engineering" course! This course is a 6-week journey designed to equip you with the knowledge and skills to build and deploy autonomous AI agents using a variety of cutting-edge frameworks and technologies.
 
-![Autonomous Agent](assets/autonomy.png)
+## Structure of the Repository
 
-_If you're looking at this in Cursor, please right click on the filename in the Explorer on the left, and select "Open preview", to view the formatted version._
+The repository is organized into several key sections to guide you through the course material:
 
-I couldn't be more excited to welcome you! This is the start of your 6 week adventure into the powerful, astonishing and often surreal world of Agentic AI.
+*   **Numbered Directories (Weeks 1-6):** Each directory corresponds to a week of the course, focusing on a specific theme or technology:
+    *   `1_foundations/`: **Week 1 - Foundations.** Introduces fundamental concepts of interacting with Large Language Models (LLMs) via APIs (primarily OpenAI). Covers building simple applications with Gradio, basic prompt engineering, and an introduction to function calling.
+    *   `2_openai/`: **Week 2 - OpenAI Agents SDK.** Focuses on the `openai-agents` library for building more structured agents. Explores creating individual agents, multi-agent collaboration for tasks like research, and using the SDK's tracing capabilities for observability.
+    *   `3_crew/`: **Week 3 - CrewAI.** Introduces the CrewAI framework for orchestrating role-based, collaborative AI agents. Covers defining agents with specific roles, goals, and backstories, assigning them tasks, and managing their execution flow.
+    *   `4_langgraph/`: **Week 4 - LangGraph.** Dives into LangGraph for building stateful, multi-actor applications. Explores creating cyclical graphs, managing state, integrating various tools (web browsing, file system), and implementing complex agentic loops with evaluation and self-correction.
+    *   `5_autogen/`: **Week 5 - AutoGen.** Focuses on Microsoft's AutoGen framework. Covers building multi-agent conversational applications, dynamic agent creation at runtime, and hints at distributed agent architectures using gRPC.
+    *   `6_mcp/`: **Week 6 - Model Context Protocol (MCP).** Explores using the OpenAI Agents SDK with MCP to integrate a wide array of external tools and services. Features a complex multi-agent financial trading simulation as a capstone example.
 
-### Before you begin
+*   `guides/`: This directory contains a series of self-study guides designed to build your technical expertise on topics relevant to the course. These include:
+    *   Command-line usage
+    *   Git and GitHub
+    *   Technical foundations (environment variables, networks, APIs)
+    *   Jupyter Notebooks
+    *   Python foundations (basic to intermediate, including async)
+    *   "Vibe coding" with LLMs and debugging techniques
+    *   Understanding AI APIs, Ollama for local models, and project startup advice.
+    *   *(Refer to `guides/01_intro.ipynb` for a full list and introduction.)*
 
-I'm here to help you be most successful! Please do reach out if I can help, either in the platform or by emailing me direct (ed@edwarddonner.com). It's always great to connect with people on LinkedIn to build up the community - you'll find me here:  
-https://www.linkedin.com/in/eddonner/  
-And this is new to me, but I'm also trying out X/Twitter at [@edwarddonner](https://x.com/edwarddonner) - if you're on X, please show me how it's done 😂  
+*   `setup/`: This directory provides comprehensive instructions for setting up your development environment across different operating systems (Windows, WSL, macOS, Linux). It includes:
+    *   Platform-specific setup files (`SETUP-PC.md`, `SETUP-mac.md`, etc.).
+    *   A Python script (`diagnostics.py`) to help identify and report setup issues.
+    *   An interactive Jupyter notebook (`troubleshooting.ipynb`) for step-by-step problem-solving.
 
-### The not-so-dreaded setup instructions
+## How to Get Started
 
-Perhaps famous last words: but I really, truly hope that I've put together an environment that will be not too horrific to set up!
+1.  **Review the Original README (`README.md.original`):** Before diving into setup or weekly content, please read `README.md.original`. It contains crucial information about the course philosophy, instructor contact details, API cost considerations, and general advice for success in the course.
+2.  **Set Up Your Environment:** Navigate to the `setup/` directory and follow the specific guide for your operating system (e.g., `SETUP-PC.md`, `SETUP-mac.md`). This is critical for ensuring all tools and dependencies are correctly installed. Use `troubleshooting.ipynb` and `diagnostics.py` in the same folder if you encounter issues.
+3.  **Start with Week 1:** Once your environment is ready, head to the `1_foundations/` directory. It's recommended to progress through the numbered directories sequentially, as concepts often build upon each other.
+4.  **Utilize the Guides:** Refer to the notebooks in the `guides/` directory for self-paced learning on foundational topics that will support your journey through the course.
 
-- Windows people, your instructions are [here](setup/SETUP-PC.md)
-- Mac people, yours are [here](setup/SETUP-mac.md)
-- Linux people, yours are [here](setup/SETUP-linux.md)
+## Content Overview of Each Module
 
-Any problems, please do contact me.
+Here's a brief overview of what you'll find in each weekly module:
 
-### Important notes for CrewAI week (Week 3)
+*   **`1_foundations/` (Foundations):**
+    *   **Topic:** Basics of LLM interaction, simple app development.
+    *   **Concepts/Projects:** Using the OpenAI API, creating Gradio web UIs, function calling, RAG example with a personalized chatbot.
 
-Windows PC users: you will need to have checked the "gotcha #4" at the top of the [SETUP-PC](setup/SETUP-PC.md) instructions -- installing Microsoft Build Tools.  
-Then, you will need to run this command in a Cursor Terminal in the project root directory in order to run the Crew commands:  
-`uv tool install crewai`   
-And in case you've used Crew before, it might be worth doing this to make sure you have the latest:  
-`uv tool upgrade crewai`  
+*   **`2_openai/` (OpenAI Agents SDK):**
+    *   **Topic:** Building agents with the `openai-agents` library.
+    *   **Concepts/Projects:** Defining `Agent` and `Runner` objects, multi-agent collaboration for a "Deep Research" task (planning, searching, writing, emailing), Pydantic for structured data, observability via tracing.
 
-Then please keep in mind for Crew:
+*   **`3_crew/` (CrewAI):**
+    *   **Topic:** Orchestrating role-based AI agent crews.
+    *   **Concepts/Projects:** Defining agents with roles/goals/backstories, assigning tasks, sequential task execution. Examples include a "Coder" crew that writes and executes code. Configuration is managed via YAML files.
 
-1. There are two ways that you can work on the CrewAI project in week 3. Either review the code for each project while I build it, and then do `crewai run` to see it in action. Or if you prefer to be more hands-on, then create your own Crew project from scratch to mirror mine; for example, create `my_debate` to go alongside `debate`, and write the code alongside me. Either approach works!  
-2. Windows users: there's a new issue that was recently introduced by one of Crew's libraries. Until this is fixed, you might get a "unicode" error when you try to run `crewai create crew`.  If that happens, please try running this command in the Terminal first: `$env:PYTHONUTF8 = "1"`  
+*   **`4_langgraph/` (LangGraph):**
+    *   **Topic:** Building stateful, multi-actor agentic applications.
+    *   **Concepts/Projects:** `StateGraph` for defining state and flow, nodes as processing units, conditional edges for dynamic routing. The "Sidekick" project demonstrates a worker-evaluator loop with tool integration (web browsing, file management) and persistent memory.
 
-### Super useful resources
+*   **`5_autogen/` (AutoGen):**
+    *   **Topic:** Developing multi-agent conversational applications with dynamic agent creation.
+    *   **Concepts/Projects:** `AssistantAgent` for conversations, tool integration (e.g., SQLite DB for flight prices), dynamic agent generation by a "Creator" agent, and gRPC for potential distributed setups.
 
-- The course [resources](https://edwarddonner.com/2025/04/21/the-complete-agentic-ai-engineering-course/) with videos
-- Many essential guides in the [guides](guides/01_intro.ipynb) section
-- The [troubleshooting](setup/troubleshooting.ipynb) notebook
+*   **`6_mcp/` (Model Context Protocol):**
+    *   **Topic:** Extending OpenAI Agents with external tools via MCP.
+    *   **Concepts/Projects:** `MCPServerStdio` for integrating tools as external services. A sophisticated multi-agent financial trading simulation showcases agents (Traders, Researchers) using various LLMs and MCP-provided tools for market data, search, and account management, monitored by a Gradio dashboard.
 
-### API costs - please read me!
+## Community Contributions
 
-This course does involve making calls to OpenAI and other frontier models, requiring an API key and a small spend, which we set up in the SETUP instructions. If you'd prefer not to spend on API calls, there are cheaper alternatives like DeepSeek and free alternatives like using Ollama!
+Each numbered weekly directory (e.g., `1_foundations/`, `2_openai/`, etc.) contains a `community_contributions/` subdirectory. These folders house projects, examples, and explorations shared by the course community.
 
-Details are [here](guides/09_ai_apis_and_ollama.ipynb).
+*   **Content:** You'll find a variety of contributions, including:
+    *   Alternative solutions or extensions to course labs.
+    *   Projects applying the weekly concepts to new domains.
+    *   Explorations with different LLMs or tools.
+    *   In later weeks (`4_langgraph` onwards), contributions are often consolidated into a `community.ipynb` notebook, which might contain smaller examples, discussions, or links.
+*   **Purpose:** These contributions offer diverse perspectives and practical applications of the course material.
 
-Be sure to monitor your API costs to ensure you are totally happy with any spend. For OpenAI, the dashboard is [here](https://platform.openai.com/usage).
+## Original Main README (`README.md.original`)
 
-### ABOVE ALL ELSE -
+As mentioned in "How to Get Started", the `README.md.original` file contains the original welcome message, course philosophy, instructor information, detailed notes on API costs, and other vital context for the course. This new `README.md` you are currently reading serves as a technical guide to the repository's structure and content.
 
-Be sure to have fun with the course! You could not have picked a better time to be learning about Agentic AI. I hope you enjoy every single minute! And if you get stuck at any point - [contact me](https://www.linkedin.com/in/eddonner/).
+---
+
+We hope this structured overview helps you navigate the repository and make the most of your AI Agentic Engineering learning experience. Happy building!

--- a/README.md.original
+++ b/README.md.original
@@ -1,0 +1,56 @@
+## Master AI Agentic Engineering -  build autonomous AI Agents
+
+### 6 week journey to code and deploy AI Agents with OpenAI Agents SDK, CrewAI, LangGraph, AutoGen and MCP
+
+![Autonomous Agent](assets/autonomy.png)
+
+_If you're looking at this in Cursor, please right click on the filename in the Explorer on the left, and select "Open preview", to view the formatted version._
+
+I couldn't be more excited to welcome you! This is the start of your 6 week adventure into the powerful, astonishing and often surreal world of Agentic AI.
+
+### Before you begin
+
+I'm here to help you be most successful! Please do reach out if I can help, either in the platform or by emailing me direct (ed@edwarddonner.com). It's always great to connect with people on LinkedIn to build up the community - you'll find me here:  
+https://www.linkedin.com/in/eddonner/  
+And this is new to me, but I'm also trying out X/Twitter at [@edwarddonner](https://x.com/edwarddonner) - if you're on X, please show me how it's done 😂  
+
+### The not-so-dreaded setup instructions
+
+Perhaps famous last words: but I really, truly hope that I've put together an environment that will be not too horrific to set up!
+
+- Windows people, your instructions are [here](setup/SETUP-PC.md)
+- Mac people, yours are [here](setup/SETUP-mac.md)
+- Linux people, yours are [here](setup/SETUP-linux.md)
+
+Any problems, please do contact me.
+
+### Important notes for CrewAI week (Week 3)
+
+Windows PC users: you will need to have checked the "gotcha #4" at the top of the [SETUP-PC](setup/SETUP-PC.md) instructions -- installing Microsoft Build Tools.  
+Then, you will need to run this command in a Cursor Terminal in the project root directory in order to run the Crew commands:  
+`uv tool install crewai`   
+And in case you've used Crew before, it might be worth doing this to make sure you have the latest:  
+`uv tool upgrade crewai`  
+
+Then please keep in mind for Crew:
+
+1. There are two ways that you can work on the CrewAI project in week 3. Either review the code for each project while I build it, and then do `crewai run` to see it in action. Or if you prefer to be more hands-on, then create your own Crew project from scratch to mirror mine; for example, create `my_debate` to go alongside `debate`, and write the code alongside me. Either approach works!  
+2. Windows users: there's a new issue that was recently introduced by one of Crew's libraries. Until this is fixed, you might get a "unicode" error when you try to run `crewai create crew`.  If that happens, please try running this command in the Terminal first: `$env:PYTHONUTF8 = "1"`  
+
+### Super useful resources
+
+- The course [resources](https://edwarddonner.com/2025/04/21/the-complete-agentic-ai-engineering-course/) with videos
+- Many essential guides in the [guides](guides/01_intro.ipynb) section
+- The [troubleshooting](setup/troubleshooting.ipynb) notebook
+
+### API costs - please read me!
+
+This course does involve making calls to OpenAI and other frontier models, requiring an API key and a small spend, which we set up in the SETUP instructions. If you'd prefer not to spend on API calls, there are cheaper alternatives like DeepSeek and free alternatives like using Ollama!
+
+Details are [here](guides/09_ai_apis_and_ollama.ipynb).
+
+Be sure to monitor your API costs to ensure you are totally happy with any spend. For OpenAI, the dashboard is [here](https://platform.openai.com/usage).
+
+### ABOVE ALL ELSE -
+
+Be sure to have fun with the course! You could not have picked a better time to be learning about Agentic AI. I hope you enjoy every single minute! And if you get stuck at any point - [contact me](https://www.linkedin.com/in/eddonner/).


### PR DESCRIPTION
This commit introduces a new README.md file that provides a thorough overview of the Agentic AI Engineering course repository.

The new documentation covers:
- The overall purpose and structure of the repository.
- Detailed descriptions of each main module/section (Weeks 1-6), including the AI concepts, frameworks (OpenAI SDK, CrewAI, LangGraph, AutoGen, MCP), and key projects.
- Information about the `guides/` directory for self-study and the `setup/` directory for environment configuration.
- Guidance on how to get started with the course materials.
- A section on `community_contributions`, highlighting their location and nature.

The original README.md has been renamed to `README.md.original` to preserve its content, which includes course philosophy, API cost information, and instructor details.